### PR TITLE
Another round of edits

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,7 +55,7 @@ services:
 
   # Postgres DB
   db:
-    image: postgres:12.4-alpine
+    image: postgres:15-bookworm
     environment:
       POSTGRES_USER: redwood
       POSTGRES_PASSWORD: redwood

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,7 +62,7 @@ services:
 
   # Postgres DB
   db:
-    image: postgres:12.4-alpine
+    image: postgres:15-bookworm
     environment:
       POSTGRES_USER: redwood
       POSTGRES_PASSWORD: redwood


### PR DESCRIPTION
Another round of edits to the Dockerfile:

- Making the workdir after switching the user saves us a `RUN` statement
- I'm not convinced the first `yarn cache clean` does anything. I haven't observed any file or size differences with or without it (using dive). It appears to modify yarn's v8 compile cache, but this cache is for the yarn binary itself, not for packages it installs, and can't be cleaned. That command also uses the yarn binary in the base image, which is v1.22.19. We don't run installs with that one; the version we use in redwood apps is different
- Colocating `CI=1` with the command we know it affects, which is `yarn install`
- The yarn plugins directory change at a slower frequency than the other files so I moved it up
- I don't see a reason not to use the latest version of postgres which is also based on the bookworm slim image